### PR TITLE
Mark Payer City/State/Zip Segment (N4) as situational

### DIFF
--- a/lib/stupidedi/guides/005010/X223-HC837I.rb
+++ b/lib/stupidedi/guides/005010/X223-HC837I.rb
@@ -2476,7 +2476,7 @@ module Stupidedi
                   b::Element(e::Required,    "Payer Address Line"),
                   b::Element(e::Situational, "Payer Address Line")),
                 b::Segment(300, s::N4, "Payer City, State, ZIP Code",
-                  r::Required, d::RepeatCount.bounded(1),
+                  r::Situational, d::RepeatCount.bounded(1),
                   b::Element(e::Required,    "Payer City Name"),
                   b::Element(e::Situational, "Payer State Code"),
                   b::Element(e::Situational, "Payer Postal Zone or ZIP Code"),


### PR DESCRIPTION
We have traditionally send a payer address for eMedNY. But Emblem didn't include it in their sample file. And from the 837 spec below, it seems pretty clear that this is a bug and that it should be marked "Situational" (but we can continue to include the address for any payers that do want or require it):

<img width="507" alt="screen shot 2018-04-01 at 1 44 31 pm" src="https://user-images.githubusercontent.com/1296815/38175922-de0281ee-35b2-11e8-8e8d-5e9d2409d966.png">
