### PR TITLE
[FCM-nil] Remove has_rdoc from gemspec

### DIFF
--- a/stupidedi.gemspec
+++ b/stupidedi.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
                          "doc/**/*.md",
                          "spec/**/*"].map { |glob| Dir[glob] }.flatten
   s.test_files        = Dir["spec/examples/**/*.example"].to_a
-  s.has_rdoc          = false
   s.bindir            = "bin"
   s.executables       = ["edi-pp", "edi-ed"]
   s.require_path      = "lib"


### PR DESCRIPTION
Prerequisite for Ruby 3.3 upgrade: https://github.com/footholdtech/rma/pull/6634

This PR removes the deprecated `has_rdoc=` method from the gemspec. This method was removed in [RubyGems 4.0](https://blog.rubygems.org/2025/12/03/4.0.0-released.html) and CI was failing on the `rma` repo in the Ruby 3.3 upgrade: https://app.circleci.com/pipelines/github/footholdtech/rma/30925/workflows/d4f91d3e-b732-4dd6-9699-00161501e615/jobs/466203

Once this is merged, I'll resolve this TODO item: https://github.com/footholdtech/rma/pull/6634#discussion_r3181942561